### PR TITLE
Feature/setup labels workflow

### DIFF
--- a/.github/workflows/setup-labels.yaml
+++ b/.github/workflows/setup-labels.yaml
@@ -1,0 +1,64 @@
+name: Setup Repository Labels
+
+on:
+  workflow_call:
+
+jobs:
+  setup-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if labels already exist
+        id: check-labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              const { data: labels } = await github.rest.issues.listLabelsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              });
+              
+              // 設定予定のラベルが既に存在するかチェック
+              const targetLabels = ['dependencies', 'npm'];
+              const existingLabels = labels.map(label => label.name);
+              const hasTargetLabels = targetLabels.some(label => existingLabels.includes(label));
+              
+              if (hasTargetLabels) {
+                console.log('Target labels already exist. Skipping setup.');
+                return 'skip';
+              }
+              
+              return 'proceed';
+            } catch (error) {
+              console.error('Error checking labels:', error);
+              return 'proceed';
+            }
+
+      - name: Setup Labels
+        if: steps.check-labels.outputs.result == 'proceed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [
+              { name: 'enhancement', color: 'a2eeef', description: 'New feature or request' },
+              { name: 'npm', color: 'cb3837', description: 'Related to npm packages and Node.js dependencies' }
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                });
+                console.log(`✅ Created label: ${label.name}`);
+              } catch (error) {
+                if (error.status === 422) {
+                  console.log(`⚠️ Label already exists: ${label.name}`);
+                } else {
+                  console.error(`❌ Error creating label ${label.name}:`, error);
+                }
+              }
+            }

--- a/.github/workflows/setup-labels.yaml
+++ b/.github/workflows/setup-labels.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           script: |
             const labels = [
-              { name: 'enhancement', color: 'a2eeef', description: 'New feature or request' },
+              { name: 'dependencies', color: '0366d6', description: 'Pull requests that update a dependency file' },
               { name: 'npm', color: 'cb3837', description: 'Related to npm packages and Node.js dependencies' }
             ];
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the setup of repository labels.

**Repository label automation:**

* Added a new workflow file `.github/workflows/setup-labels.yaml` that checks for the existence of specific labels (`dependencies`, `npm`) and creates standard labels (`dependencies`, `npm`) if they don't exist, using `actions/github-script`.