### PR TITLE
feat: add workflows to assign issue and PR authors.

### DIFF
--- a/.github/workflows/assign-issue-author.yaml
+++ b/.github/workflows/assign-issue-author.yaml
@@ -1,0 +1,21 @@
+name: Assign Issue Author
+on:
+  issues:
+    types: [opened]
+jobs:
+  assign-issue-author:
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Assign issue creator
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              assignees: [context.payload.issue.user.login],
+            })

--- a/.github/workflows/assign-pr-author.yaml
+++ b/.github/workflows/assign-pr-author.yaml
@@ -1,0 +1,21 @@
+name: Assign PR Author
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  assign-pr-author:
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Assign PR creator
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees: [context.payload.pull_request.user.login]
+            })


### PR DESCRIPTION
This pull request adds two new GitHub Actions workflows to automate assigning the author to newly created issues and pull requests. These workflows ensure that the creator is automatically set as the assignee, improving project management and visibility.

**Automation workflows:**

* Added `.github/workflows/assign-issue-author.yaml` to automatically assign the issue creator as the assignee when a new issue is opened, excluding bot users.
* Added `.github/workflows/assign-pr-author.yaml` to automatically assign the pull request creator as the assignee when a new pull request is opened, excluding bot users.